### PR TITLE
Indicate senior members in member list

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -48,4 +48,8 @@ class Member < ApplicationRecord
     end
   end
 
+  def senior?
+    date_of_birth.present? && date_of_birth < 60.years.ago.to_date
+  end
+
 end

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -41,11 +41,16 @@
         <td><%= member.custom_number %></td>
         <td><%= member.tamil_name %></td>
         <td>
-          <% if policy(member).edit? %>
-            <%= link_to member.name, edit_member_path(member), class: 'link-primary' %>
-          <% else %>
-            <%= member.name %>
-          <% end %>
+          <div class="flex items-center gap-2">
+            <% if policy(member).edit? %>
+              <%= link_to member.name, edit_member_path(member), class: 'link-primary' %>
+            <% else %>
+              <%= member.name %>
+            <% end %>
+            <% if member.senior? %>
+              <span class="rounded-full bg-yellow-100 px-2 py-1 text-xs font-semibold text-yellow-800"><%= t('senior_member') %></span>
+            <% end %>
+          </div>
         </td>
         <td><%= member.personal_number %></td>
         <td><%= member.section %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   members: "Members"
+  senior_member: "Senior"
   new_member: "New Member"
   search_by_name_id_or_personal_number: "Search by name, ID or personal number"
   search: "Search"

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -1,5 +1,6 @@
 ta:
   members: "உறுப்பினர்கள்"
+  senior_member: "மூத்த உறுப்பினர்"
   new_member: "புதிய உறுப்பினர்"
   search_by_name_id_or_personal_number: "உறுப்பினர் எண், பெயர் அல்லது நிரந்தர எண் மூலம் தேடவும்"
   search: "தேடு"

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -156,6 +156,17 @@ class MembersControllerTest < ActionDispatch::IntegrationTest
     assert_select 'td', text: member.name
   end
 
+  test 'member list marks members older than 60 as senior' do
+    member = members(:johnny)
+    member.update!(date_of_birth: 61.years.ago.to_date)
+    log_in_as(staffs(:admino))
+
+    get members_path
+
+    assert_response :success
+    assert_select 'span', text: I18n.t('senior_member'), count: 1
+  end
+
   test 'should throw flash when creating a second member with same mobile number' do
     log_in_as staffs(:admino)
     assert_difference 'Member.count' do

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -122,4 +122,23 @@ class MemberTest < ActiveSupport::TestCase
     Member.expects(:all).once
     Member.filter_by_can_rent('false')
   end
+
+  test 'senior? is true only when the member is older than 60' do
+    travel_to Date.new(2026, 8, 31) do
+      @member.date_of_birth = Date.new(1966, 8, 30)
+      assert_predicate @member, :senior?
+
+      @member.date_of_birth = Date.new(1966, 8, 31)
+      assert_not_predicate @member, :senior?
+
+      @member.date_of_birth = Date.new(1966, 9, 1)
+      assert_not_predicate @member, :senior?
+    end
+  end
+
+  test 'senior? is false when the date of birth is missing' do
+    @member.date_of_birth = nil
+
+    assert_not_predicate @member, :senior?
+  end
 end


### PR DESCRIPTION
## Summary\n- add a senior status predicate for members strictly older than 60\n- show a localized amber Senior badge in the members index\n- cover date boundaries and index rendering\n\n## Testing\n-  *(blocked: Ruby 3.2.2 is not installed in this environment)*\n- 